### PR TITLE
Add zlib library when building bigbed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -290,6 +290,7 @@ try:
     bigbed = Extension(
         "plastid.readers.bigbed",
         ["plastid/readers/bigbed.pyx"] + kent_deps,
+        libraries=LIBRARIES + ["z"],
         **extension_kwargs
     )
 


### PR DESCRIPTION
This seems to fix the second issue described in #29: `undefined symbol: compress` error.